### PR TITLE
feat: simplify AI action UI in suggestion panel

### DIFF
--- a/apps/ai-service/src/modules/jobs/jobController.ts
+++ b/apps/ai-service/src/modules/jobs/jobController.ts
@@ -202,7 +202,11 @@ export const jobController = {
       res.flushHeaders?.();
 
       const abortController = new AbortController();
-      req.on("close", () => abortController.abort());
+      res.on("close", () => {
+        if (!res.writableEnded) {
+          abortController.abort();
+        }
+      });
 
       writeSse(res, "meta", { jobId });
 

--- a/apps/ai-service/src/modules/jobs/promptTemplates.ts
+++ b/apps/ai-service/src/modules/jobs/promptTemplates.ts
@@ -138,6 +138,35 @@ ${text}
 `.trim();
       }
 
+      if (formatStyle === "structured_notes") {
+        return `
+You are an assistant helping improve a document.
+
+Task:
+Reformat the text into clean structured notes.
+
+STRICT REQUIREMENTS:
+- Output plain text only
+- Do NOT use Markdown
+- Do NOT use **bold**, headings with #, or code blocks
+- Use short labels and bullets where helpful
+- Preserve the original meaning
+- Do not add new facts
+
+CORRECT FORMAT EXAMPLE:
+Topic
+- Key point
+- Key point
+Details:
+- Item
+- Item
+
+--- BEGIN TEXT ---
+${text}
+--- END TEXT ---
+`.trim();
+      }
+
       return `
 You are an assistant helping improve a document.
 

--- a/apps/api/src/modules/ai/aiJobController.ts
+++ b/apps/api/src/modules/ai/aiJobController.ts
@@ -215,7 +215,11 @@ export const aiJobController = {
       res.flushHeaders?.();
 
       const abortController = new AbortController();
-      req.on("close", () => abortController.abort());
+      res.on("close", () => {
+        if (!res.writableEnded) {
+          abortController.abort();
+        }
+      });
 
       const out = await aiJobService.streamJob({
         documentId,
@@ -312,10 +316,19 @@ export const aiJobController = {
         throw apiError(ERROR_CODES.INVALID_REQUEST, "documentId is required");
       }
 
+      const rawLimit = req.query.limit;
+      const parsedLimit =
+        typeof rawLimit === "string" && Number.isFinite(Number(rawLimit))
+          ? Math.floor(Number(rawLimit))
+          : 20;
+
+      const safeLimit = Math.max(1, Math.min(parsedLimit, 100));
+
       const history = await aiJobService.listHistory(
         documentId,
         user.id,
-        getDocumentLinkToken(req)
+        getDocumentLinkToken(req),
+        safeLimit
       );
       return res.json(history);
     } catch (err) {

--- a/apps/api/src/modules/ai/aiJobRepo.ts
+++ b/apps/api/src/modules/ai/aiJobRepo.ts
@@ -79,7 +79,10 @@ export const aiJobRepo = {
     });
   },
 
-  async listByDocument(documentId: string) {
+  async listByDocument(documentId: string, limit?: number) {
+    const take =
+      typeof limit === "number" && limit > 0 ? Math.floor(limit) : undefined;
+
     return prisma.aIJob.findMany({
       where: { documentId },
       orderBy: { createdAt: "desc" },
@@ -95,6 +98,7 @@ export const aiJobRepo = {
           },
         },
       },
+      ...(typeof take === "number" ? { take } : {}),
     });
   },
 

--- a/apps/api/src/modules/ai/aiJobService.ts
+++ b/apps/api/src/modules/ai/aiJobService.ts
@@ -634,7 +634,7 @@ export const aiJobService = {
     }
   },
 
-  async listHistory(documentId: string, requesterId: string, linkToken?: string) {
+  async listHistory(documentId: string, requesterId: string, linkToken?: string, limit = 20) {
     const role = await permissionService.resolveEffectiveRole({
       documentId,
       userId: requesterId,
@@ -644,7 +644,7 @@ export const aiJobService = {
       throw apiError(ERROR_CODES.FORBIDDEN, "No access to this document");
     }
 
-    const jobs = await aiJobRepo.listByDocument(documentId);
+    const jobs = await aiJobRepo.listByDocument(documentId, limit);
 
     return jobs.map((job) => {
       const params =

--- a/apps/web/src/components/layout/AIHistoryPanel.tsx
+++ b/apps/web/src/components/layout/AIHistoryPanel.tsx
@@ -49,7 +49,7 @@ export function AIHistoryPanel({ documentId }: Props) {
     setError(null);
 
     try {
-      const data = await listAIHistory(documentId);
+      const data = await listAIHistory(documentId, 20);
       setItems(Array.isArray(data) ? data : []);
     } catch (err: unknown) {
       setError(getErrorMessage(err, "Failed to load AI history"));

--- a/apps/web/src/features/ai/AISuggestionPanel.tsx
+++ b/apps/web/src/features/ai/AISuggestionPanel.tsx
@@ -38,7 +38,7 @@ type Props = {
 type Mode = "idle" | "running" | "ready" | "error";
 type NoticeKind = "info" | "error" | "conflict";
 
-type EnhanceStyle = "clearer" | "concise" | "professional" | "formal";
+type EnhanceStyle = "clearer" | "concise" | "professional";
 type SummaryStyle = "short_paragraph" | "bullet_points";
 type ReformatStyle =
   | "bullet_list"
@@ -84,7 +84,6 @@ const ENHANCE_OPTIONS: Array<{ value: EnhanceStyle; label: string }> = [
   { value: "clearer", label: "Clearer" },
   { value: "concise", label: "More concise" },
   { value: "professional", label: "More professional" },
-  { value: "formal", label: "More formal" },
 ];
 
 const SUMMARY_OPTIONS: Array<{ value: SummaryStyle; label: string }> = [
@@ -93,6 +92,7 @@ const SUMMARY_OPTIONS: Array<{ value: SummaryStyle; label: string }> = [
 ];
 
 const LANGUAGE_OPTIONS = ["Arabic", "English", "French", "Spanish", "German"];
+const MAX_CUSTOM_LANGUAGE_LENGTH = 60;
 
 const REFORMAT_OPTIONS: Array<{ value: ReformatStyle; label: string }> = [
   { value: "bullet_list", label: "Bullet list" },
@@ -109,6 +109,10 @@ function clampPreview(text: string, max = 220) {
 
 function normalizeWhitespace(text: string) {
   return text.replace(/\r\n/g, "\n").replace(/\t/g, "  ").trim();
+}
+
+function normalizeCustomLanguage(text: string) {
+  return text.replace(/\s+/g, " ").trim();
 }
 
 function dedupeBrokenTail(text: string) {
@@ -173,6 +177,27 @@ function cleanBulletOutput(text: string) {
   return dedupeBrokenTail(cleanedLines.join("\n")).trim();
 }
 
+function cleanStructuredNotesOutput(text: string) {
+  const normalized = normalizeWhitespace(text)
+    .replace(/\*\*(.*?)\*\*/g, "$1")
+    .replace(/__(.*?)__/g, "$1")
+    .replace(/^\s*#+\s*/gm, "")
+    .replace(/[ \t]+$/gm, "");
+
+  const lines = normalized
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      if (line.startsWith("- ") || line.startsWith("* ")) {
+        return `- ${line.replace(/^[-*]\s*/, "").trim()}`;
+      }
+      return line;
+    });
+
+  return dedupeBrokenTail(lines.join("\n")).trim();
+}
+
 function shouldNormalizeAsBullets(
   operation: AIOperation,
   summaryStyle: SummaryStyle,
@@ -221,12 +246,9 @@ export function AISuggestionPanel({ documentId, selection, onApplied }: Props) {
   const [error, setError] = useState<string | null>(null);
   const [noticeKind, setNoticeKind] = useState<NoticeKind>("info");
   const [finalText, setFinalText] = useState("");
-  const [selectedDraftText, setSelectedDraftText] = useState("");
-
   const frozenSelectionRef = useRef<FrozenSelection | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
   const modeRef = useRef<Mode>("idle");
-  const suggestionRef = useRef<HTMLTextAreaElement | null>(null);
 
   const selectionLen = useMemo(
     () => Math.max(0, (selection?.end ?? 0) - (selection?.start ?? 0)),
@@ -237,6 +259,17 @@ export function AISuggestionPanel({ documentId, selection, onApplied }: Props) {
     () => (selection?.end ?? 0) > (selection?.start ?? 0),
     [selection?.start, selection?.end]
   );
+
+  const hasCustomLanguageInput = customLanguage.length > 0;
+  const normalizedCustomLanguage = useMemo(
+    () => normalizeCustomLanguage(customLanguage).slice(0, MAX_CUSTOM_LANGUAGE_LENGTH),
+    [customLanguage]
+  );
+  const customLanguageError = useMemo(() => {
+    if (operation !== "translate" || !hasCustomLanguageInput) return null;
+    if (!normalizedCustomLanguage) return "Custom language cannot be empty.";
+    return null;
+  }, [operation, hasCustomLanguageInput, normalizedCustomLanguage]);
 
   const selectionPreview = useMemo(() => {
     const t = selection?.text ?? "";
@@ -255,9 +288,9 @@ export function AISuggestionPanel({ documentId, selection, onApplied }: Props) {
     finalText.trim().length > 0;
 
   const effectiveLanguage = useMemo(() => {
-    const custom = customLanguage.trim();
+    const custom = normalizedCustomLanguage;
     return custom.length > 0 ? custom : language;
-  }, [customLanguage, language]);
+  }, [normalizedCustomLanguage, language]);
 
   const applyHint = useMemo(() => {
     if (activeOp.applyMode === "insert_below") {
@@ -271,6 +304,10 @@ export function AISuggestionPanel({ documentId, selection, onApplied }: Props) {
 
     if (shouldNormalizeAsBullets(operation, summaryStyle, reformatStyle)) {
       return cleanBulletOutput(text);
+    }
+
+    if (operation === "reformat" && reformatStyle === "structured_notes") {
+      return cleanStructuredNotesOutput(text);
     }
 
     return dedupeBrokenTail(text);
@@ -287,6 +324,11 @@ export function AISuggestionPanel({ documentId, selection, onApplied }: Props) {
 
   async function run() {
     if (!canRun || isRunning) return;
+    if (customLanguageError) {
+      setError(customLanguageError);
+      setNoticeKind("error");
+      return;
+    }
 
     const targetSelection: FrozenSelection = {
       start: selection.start,
@@ -419,6 +461,10 @@ export function AISuggestionPanel({ documentId, selection, onApplied }: Props) {
     await run();
   }
 
+  function handleCustomLanguageBlur() {
+    setCustomLanguage(normalizedCustomLanguage);
+  }
+
   function reset() {
     abortControllerRef.current?.abort();
     abortControllerRef.current = null;
@@ -427,7 +473,6 @@ export function AISuggestionPanel({ documentId, selection, onApplied }: Props) {
     setJob(null);
     setMode("idle");
     setFinalText("");
-    setSelectedDraftText("");
     frozenSelectionRef.current = null;
   }
 
@@ -445,26 +490,6 @@ export function AISuggestionPanel({ documentId, selection, onApplied }: Props) {
 
   function cancelGeneration() {
     abortControllerRef.current?.abort();
-  }
-
-  function captureDraftSelection() {
-    const textarea = suggestionRef.current;
-    if (!textarea) {
-      setSelectedDraftText("");
-      return;
-    }
-
-    const start = textarea.selectionStart ?? 0;
-    const end = textarea.selectionEnd ?? 0;
-    const selected = finalText.slice(start, end).trim();
-    setSelectedDraftText(selected);
-  }
-
-  function useSelectedPortion() {
-    const trimmed = normalizeSuggestionText(selectedDraftText);
-    if (!trimmed) return;
-    setFinalText(trimmed);
-    setSelectedDraftText("");
   }
 
   return (
@@ -618,11 +643,22 @@ export function AISuggestionPanel({ documentId, selection, onApplied }: Props) {
                 <div className="mt-2">
                   <Input
                     value={customLanguage}
-                    onChange={(e) => setCustomLanguage(e.target.value)}
+                    onChange={(e) =>
+                      setCustomLanguage(e.target.value.slice(0, MAX_CUSTOM_LANGUAGE_LENGTH))
+                    }
+                    onBlur={handleCustomLanguageBlur}
                     placeholder="Optional: Italian, Urdu, Turkish"
                     disabled={isRunning}
+                    maxLength={MAX_CUSTOM_LANGUAGE_LENGTH}
                   />
                 </div>
+                {customLanguageError ? (
+                  <div className="mt-2 text-xs text-red-600">{customLanguageError}</div>
+                ) : (
+                  <div className="mt-2 text-xs text-slate-500">
+                    Optional. Overrides the preset language when filled.
+                  </div>
+                )}
               </div>
             </>
           )}
@@ -654,14 +690,16 @@ export function AISuggestionPanel({ documentId, selection, onApplied }: Props) {
 
         <div className="mt-4">
           <div className="flex flex-wrap items-center gap-2">
-            <Button
-              variant="primary"
-              onClick={run}
-              disabled={!canRun || isRunning}
-              className="w-full sm:w-auto"
-            >
-              {isRunning ? "Generating..." : "Generate"}
-            </Button>
+            {mode === "idle" && (
+              <Button
+                variant="primary"
+                onClick={run}
+                disabled={!canRun || isRunning || Boolean(customLanguageError)}
+                className="w-full sm:w-auto"
+              >
+                Generate
+              </Button>
+            )}
 
             {isRunning && (
               <Button
@@ -673,14 +711,16 @@ export function AISuggestionPanel({ documentId, selection, onApplied }: Props) {
               </Button>
             )}
 
-            <Button
-              variant="secondary"
-              onClick={apply}
-              disabled={!canApply}
-              className="w-full sm:w-auto"
-            >
-              Accept
-            </Button>
+            {(mode === "ready" || (mode === "error" && noticeKind === "conflict")) && (
+              <Button
+                variant="primary"
+                onClick={apply}
+                disabled={!canApply}
+                className="w-full sm:w-auto"
+              >
+                Accept
+              </Button>
+            )}
 
             {(mode === "ready" || mode === "error") && (
               <Button
@@ -693,19 +733,19 @@ export function AISuggestionPanel({ documentId, selection, onApplied }: Props) {
               </Button>
             )}
 
-            {(mode === "ready" || (mode === "error" && noticeKind === "conflict")) && (
+            {(mode === "ready" || mode === "error") && (
               <Button
                 variant="ghost"
-                onClick={useSelectedPortion}
-                disabled={selectedDraftText.trim().length === 0}
+                onClick={() => void rejectCurrent()}
                 className="w-full sm:w-auto"
               >
-                Use selected part
+                {mode === "ready" ? "Reject" : "Dismiss"}
               </Button>
             )}
+
           </div>
 
-          <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div className="mt-3">
             <div className="text-xs leading-relaxed text-gray-600">
               {mode === "idle" && "Ready when you are."}
               {mode === "running" && "Streaming suggestion as it is generated."}
@@ -720,16 +760,6 @@ export function AISuggestionPanel({ documentId, selection, onApplied }: Props) {
                 noticeKind === "error" &&
                 "Fix the issue and try again."}
             </div>
-
-            {(mode === "ready" || mode === "error") && (
-              <button
-                type="button"
-                onClick={() => void rejectCurrent()}
-                className="self-start text-xs font-medium text-gray-700 transition-colors hover:text-gray-900 sm:self-auto"
-              >
-                {mode === "ready" ? "Reject" : "Dismiss"}
-              </button>
-            )}
           </div>
         </div>
 
@@ -749,13 +779,9 @@ export function AISuggestionPanel({ documentId, selection, onApplied }: Props) {
 
           <div className="mt-2">
             <textarea
-              ref={suggestionRef}
               className="w-full min-h-[160px] rounded-2xl border border-slate-200 bg-white p-3 text-sm text-gray-900 shadow-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:bg-gray-50 disabled:text-gray-500"
               value={finalText}
               onChange={(e) => setFinalText(e.target.value)}
-              onSelect={captureDraftSelection}
-              onKeyUp={captureDraftSelection}
-              onMouseUp={captureDraftSelection}
               placeholder={
                 canRun
                   ? mode === "running"
@@ -791,14 +817,7 @@ export function AISuggestionPanel({ documentId, selection, onApplied }: Props) {
 
           {(mode === "ready" || (mode === "error" && noticeKind === "conflict")) && (
             <div className="mt-2 text-xs text-slate-500">
-              You can edit the suggestion before accepting it, or highlight part of it and keep
-              only that selected portion.
-            </div>
-          )}
-
-          {selectedDraftText.trim().length > 0 && (
-            <div className="mt-2 text-xs text-slate-600">
-              Selected excerpt ready: “{clampPreview(selectedDraftText.trim(), 70)}”
+              You can edit the suggestion before accepting it.
             </div>
           )}
         </div>

--- a/apps/web/src/features/ai/api.ts
+++ b/apps/web/src/features/ai/api.ts
@@ -132,8 +132,11 @@ export async function rejectAIJob(jobId: string) {
   });
 }
 
-export async function listAIHistory(documentId: string) {
-  return http<AIHistoryItem[]>(`/ai/history/${encodeURIComponent(documentId)}`);
+export async function listAIHistory(documentId: string, limit = 20) {
+  const safeLimit = Math.max(1, Math.min(limit, 100));
+  return http<AIHistoryItem[]>(
+    `/ai/history/${encodeURIComponent(documentId)}?limit=${encodeURIComponent(String(safeLimit))}`
+  );
 }
 
 export async function streamAIJob(

--- a/apps/web/src/features/editor/EditorStateManager.ts
+++ b/apps/web/src/features/editor/EditorStateManager.ts
@@ -441,7 +441,7 @@ export class EditorStateManager {
         ydocGuid: this.ydoc.guid,
       });
 
-    return [
+    const extensions = [
       ...tiptapExtensions,
 
       Collaboration.configure({
@@ -460,9 +460,26 @@ export class EditorStateManager {
             userId: user.id ?? "unknown",
             name: user.name,
             color: user.color,
-          }),
+        }),
       }),
     ];
+
+    const seen = new Set<string>();
+
+    return [...extensions].reverse().filter((ext: any) => {
+      const name =
+        typeof ext?.name === "string"
+          ? ext.name
+          : typeof ext?.config?.name === "string"
+            ? ext.config.name
+            : null;
+
+      if (!name) return true;
+      if (seen.has(name)) return false;
+
+      seen.add(name);
+      return true;
+    }).reverse();
   }
 
   private requestSync() {

--- a/apps/web/src/features/editor/pages/Editor.tsx
+++ b/apps/web/src/features/editor/pages/Editor.tsx
@@ -525,6 +525,10 @@ export function EditorPage({ documentId, onBack, onCurrentUserColorChange }: Pro
       if (!isConnected) return;
       if (!initialSyncDoneRef.current) return;
 
+      if (undoableAIChange) {
+        setUndoableAIChange(null);
+      }
+
       clearYSaveTimer();
       ySaveTimerRef.current = window.setTimeout(() => {
         const editorNow = editorRef.current;
@@ -558,6 +562,7 @@ export function EditorPage({ documentId, onBack, onCurrentUserColorChange }: Pro
     editorRef,
     documentId,
     persistDocumentContent,
+    undoableAIChange,
   ]);
 
   useEffect(() => {
@@ -749,32 +754,6 @@ export function EditorPage({ documentId, onBack, onCurrentUserColorChange }: Pro
             >
               AI Interaction History
             </button>
-
-            {docRole && ["Editor", "Owner"].includes(docRole) && (
-              <button
-                type="button"
-                onClick={() => {
-                  const trimmed = selection.text.trim();
-                  if (!trimmed) {
-                    setBanner("Select text in the editor to open AI suggestions.");
-                    return;
-                  }
-
-                  setSidePanel((cur) => (cur === "ai" ? "none" : "ai"));
-                  setPendingCommentAnchor(null);
-                  setBanner(null);
-                }}
-                className={`rounded-xl px-3 py-2 text-xs font-semibold transition-colors ${
-                  sidePanel === "ai"
-                    ? "bg-slate-900 text-white shadow-sm"
-                    : "text-slate-700 hover:bg-white hover:text-slate-900"
-                }`}
-                aria-pressed={sidePanel === "ai"}
-                title="Open AI suggestions"
-              >
-                AI Suggestions
-              </button>
-            )}
 
             {totalCommentsCount > 0 && (
               <button


### PR DESCRIPTION
- show Generate only in idle state
- group actions as Accept, Try again, Reject after generation
- move helper text below actions
- remove separate floating Reject button